### PR TITLE
[NETPATH-340] Remove noisy log statement

### DIFF
--- a/go/dublintraceroute/probes/probev4/udpv4.go
+++ b/go/dublintraceroute/probes/probev4/udpv4.go
@@ -298,7 +298,6 @@ func (d UDPv4) Match(sent []probes.Probe, received []probes.ProbeResponse) resul
 		for _, rp := range received {
 			rpu := rp.(*ProbeResponseUDPv4)
 			if err := rpu.Validate(); err != nil {
-				log.Printf("Invalid probe response: %v", err)
 				continue
 			}
 			if !rpu.Matches(spu) {

--- a/go/dublintraceroute/probes/probev6/udpv6.go
+++ b/go/dublintraceroute/probes/probev6/udpv6.go
@@ -276,7 +276,6 @@ func (d UDPv6) Match(sent []probes.Probe, received []probes.ProbeResponse) resul
 		for _, rp := range received {
 			rpu := rp.(*ProbeResponseUDPv6)
 			if err := rpu.Validate(); err != nil {
-				log.Printf("Invalid probe response: %v", err)
 				continue
 			}
 			if !rpu.Matches(spu) {


### PR DESCRIPTION
### What does this PR do?
Removes the noisy "Invalid probe response" logs from the library. After double checking, this is indeed the only log statement we're seeing in our environments from this library.

More context can be found in the ticket, but essentially this happens because the raw socket reads all ICMP packets off the wire including ones not meant for the library and while it drops them, it also logs.